### PR TITLE
Optional virtualbox install and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,12 @@ ansible-playbook -i "localhost," --ask-sudo-pass --connection=local installation
     - role: vagrant
       vagrant_version: "1.6.3"
 ```
+
+# Specify virtualbox installation (For Debian)
+```
+---
+ - hosts: all
+   roles:
+    - role: vagrant
+      vagrant_virtualbox_install: True
+      vagrant_virtualbox_ver: "virtualbox-5.1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,5 @@ vagrant_version: "1.9.1"
 vagrant_tmp_dir: "/opt/ansible_downloads/"
 vagrant_tmp_deb: "{{vagrant_tmp_dir}}/vagrant_{{vagrant_version}}.deb"
 vagrant_tmp_rpm: "{{vagrant_tmp_dir}}/vagrant_{{vagrant_version}}.rpm"
+vagrant_virtualbox_install: True
+vagrant_virtualbox_ver: "virtualbox"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install virtualbox for Debian OS family
-  apt: name=virtualbox
+  apt: name={{ vagrant_virtualbox_ver }}
+  when: ( vagrant_virtualbox_install )
 
 - name: Download vagrant
   get_url: url={{ vagrant_url_deb }} dest={{vagrant_tmp_deb}}


### PR DESCRIPTION
This patch allows you to specify an optional version (i.e. name) for the virtualbox install on Debian systems.  This is necessary if you are using the oracle repos and are installing e.g. virtualbox-5.1.  You can have both virtualbox-5.1 and virtualbox (from the default repos) installed, but they will conflict.

This also allows you to override the install by choosing false (e.g. if you are installing it from another role).